### PR TITLE
m4/docbook.m4:  if fop.sh isn't found, also check for fop

### DIFF
--- a/m4/docbook.m4
+++ b/m4/docbook.m4
@@ -67,7 +67,12 @@ AC_SUBST(DBX_XSLTPROC)
 
 AC_CHECK_PROG(DBX_FOP, fop.sh, fop.sh)
 if test x"$DBX_FOP" = x -a -n "$DBX_DOC"; then
-   AC_MSG_ERROR([fop.sh was not found. Check your PATH variable and try again.])
+   AC_CHECK_PROG(DBX_FOP, fop, fop)
+   if test -z "$DBX_FOP"; then
+      AC_MSG_ERROR(
+         [Neither fop.sh nor fop was not found. ]
+	 [Check your PATH variable and try again.])
+   fi
 fi
 AC_SUBST(DBX_FOP)
 


### PR DESCRIPTION
`fop.sh` is renamed to `fop` in Debian packages
