### PR TITLE
Fix comedilib headers

### DIFF
--- a/m4/acinclude.m4
+++ b/m4/acinclude.m4
@@ -221,10 +221,10 @@ AC_CACHE_VAL(ac_cv_comedi,[
 
     # First check to see if --with-comedi was specified.
     if test x"${with_comedi}" != x ; then
-	if test -f "${with_comedi}/include/linux/comedilib.h" ; then
+	if test -f "${with_comedi}/include/comedilib.h" ; then
 	    ac_cv_comedi=`(cd ${with_comedi}; pwd)`
 	else
-	    AC_MSG_ERROR([${with_comedi}/include directory doesn't contain linux/comedilib.h])
+	    AC_MSG_ERROR([${with_comedi}/include directory doesn't contain comedilib.h])
 	fi
     fi
 
@@ -237,7 +237,7 @@ AC_CACHE_VAL(ac_cv_comedi,[
 		`ls -dr ../../comedi* 2>/dev/null` \
 		../../../comedi \
 		`ls -dr ../../../comedi* 2>/dev/null` ; do
-	    if test -f "$i/include/linux/comedilib.h" ; then
+	    if test -f "$i/include/comedilib.h" ; then
 		ac_cv_comedi=`(cd $i; pwd)`
 		break
 	    fi
@@ -248,7 +248,7 @@ AC_CACHE_VAL(ac_cv_comedi,[
     if test x"${ac_cv_comedi}" = x ; then
 	for i in ${prefix}/comedi* /usr/local/comedi* /usr/pkg/comedi* /usr \
 		`ls -dr /usr/lib/comedi* 2>/dev/null` ; do
-	    if test -f "$i/include/linux/comedilib.h" ; then
+	    if test -f "$i/include/comedilib.h" ; then
 		ac_cv_comedi=`(cd $i; pwd)`
 		break
 	    fi
@@ -260,7 +260,7 @@ AC_CACHE_VAL(ac_cv_comedi,[
 	for i in \
 		${srcdir}/../comedi \
 		`ls -dr ${srcdir}/../comedi* 2>/dev/null` ; do
-	    if test -f "$i/include/linux/comedilib.h" ; then
+	    if test -f "$i/include/comedilib.h" ; then
 	    ac_cv_comedi=`(cd $i; pwd)`
 	    break
 	fi
@@ -270,7 +270,7 @@ AC_CACHE_VAL(ac_cv_comedi,[
 
 if test x"${ac_cv_comedi}" = x ; then
     COMEDI_DIR="# no COMEDI installation found"
-    AC_MSG_ERROR(Can't find COMEDI installation ( missing linux/comedilib.h ) )
+    AC_MSG_ERROR(Can't find COMEDI installation ( missing comedilib.h ) )
 else
     COMEDI_DIR=${ac_cv_comedi}
     AC_MSG_RESULT(found $COMEDI_DIR)


### PR DESCRIPTION
This is a patch from the upstream Debian RTAI packaging, maintained by
Roland Stigge.

It fixes the autoconf m4 macros to look for `comedilib.h` in `/usr/include` rather than `/usr/include/linux`:

```
$ find /usr/include -name comedilib.h
/usr/include/comedilib.h
$ dpkg-query -S /usr/include/comedilib.h
libcomedi-dev: /usr/include/comedilib.h
$ dpkg-query -L libcomedi-dev | grep linux/
$
```

After investigation, I found no case where the header's location might
be in `/usr/include/linux/comedilib.h`.  Debian, Ubuntu and Fedora all
install into `/usr/include/comedilib.h`, and building comedilib from
source apparently does, too.  It's starting to look like
`/usr/include/linux/comedilib.h` is an outdated location, or maybe
completely bogus:  this problem has been [reported since at least
2004](http://mail.rtai.org/pipermail/rtai/2004-October/009196.html), and hacking around the problem with a symlink is part of [at
least one RTAI tutorial](http://marc.info/?l=comedi&m=117981204228094)!

This is related to discussion in [my GitHub RTAI package repo](https://github.com/zultron/rtai-deb/issues/1#issuecomment-57822869).
